### PR TITLE
Fix cross-posted announcement relay from followed channels

### DIFF
--- a/src/services/WebhookService.ts
+++ b/src/services/WebhookService.ts
@@ -105,7 +105,7 @@ export class WebhookService {
             const { id } = await webhook.send({
                 content: data.content,
                 username: data.username,
-                avatarURL: data.avatarURL,
+                avatarURL: data.avatarURL || undefined,
                 files,
                 embeds:
                     data.embeds?.map((embed) => embed.toDiscordEmbed()) || [],
@@ -229,7 +229,7 @@ export class WebhookService {
                 {
                     content: data.content,
                     username: data.username,
-                    avatar_url: data.avatarURL,
+                    avatar_url: data.avatarURL || undefined,
                     files:
                         data.attachments?.map((attachment) => ({
                             url: attachment.url,

--- a/src/services/messageTransformer/DiscordMessageTransformer.ts
+++ b/src/services/messageTransformer/DiscordMessageTransformer.ts
@@ -11,6 +11,7 @@ import { buildDiscordStickerUrl } from '../../utils/buildStickerUrl';
 import { getPollMessage } from '../../utils/pollMessageFormatter';
 import WebhookEmbed from '../WebhookEmbed';
 import { GeneralEmoji } from '../../utils/emojis';
+import logger from '../../utils/logging/logger';
 
 type DiscordMessage = OmitPartialGroupDMChannel<Message<boolean>>;
 
@@ -103,25 +104,38 @@ export default class DiscordMessageTransformer extends MessageTransformer<
         );
 
         if (message.reference) {
-            const referencedMessage = await message.fetchReference();
-            const content = this.sanitizeContent(referencedMessage);
-            const isForwarded = message.flags.has(MessageFlags.HasSnapshot);
-            const refrenceEmoji = isForwarded ? '⏩' : '↩️';
-            if (content && content.trim() !== '') {
-                embeds.unshift(
-                    new WebhookEmbed({
-                        description: `${content}`,
-                        color: 0x0b0d0e,
-                        author: {
-                            name:
-                                referencedMessage.author.username +
-                                ` ${refrenceEmoji}`,
-                            iconURL:
-                                referencedMessage.author.avatarURL() ||
-                                undefined,
-                        },
-                    })
-                );
+            // The reply/forward context embed requires fetching the referenced
+            // message. For cross-posts and forwards from guilds the bot isn't
+            // a member of, this fetch fails — skip the decoration rather than
+            // aborting the relay of the message itself.
+            const referencedMessage = await message
+                .fetchReference()
+                .catch((err: Error) => {
+                    logger.warn(
+                        `Could not fetch referenced message; skipping reference embed: ${err.message}`
+                    );
+                    return null;
+                });
+            if (referencedMessage) {
+                const content = this.sanitizeContent(referencedMessage);
+                const isForwarded = message.flags.has(MessageFlags.HasSnapshot);
+                const refrenceEmoji = isForwarded ? '⏩' : '↩️';
+                if (content && content.trim() !== '') {
+                    embeds.unshift(
+                        new WebhookEmbed({
+                            description: `${content}`,
+                            color: 0x0b0d0e,
+                            author: {
+                                name:
+                                    referencedMessage.author.username +
+                                    ` ${refrenceEmoji}`,
+                                iconURL:
+                                    referencedMessage.author.avatarURL() ||
+                                    undefined,
+                            },
+                        })
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
# Fixes #13

Following an external announcement channel (via Discord's follow feature) and bridging that channel to Fluxer currently fails to relay any of the cross-posted messages. Two separate bugs combine to break it.

## 1. `Message.fetchReference()` aborts the relay

Cross-posted messages carry a `message.reference` pointing back to the original message in the *source* guild. The`DiscordMessageTransformer.transformMessage()` calls `fetchReference()` to render a small reply-quote embed for replies and forwards. When the bot isn't a member of the source guild, which is always the case for an external follow, discord.js throws `GuildChannelResolve`, which is unhandled and aborts the entire relay.

The fetch is now wrapped, so a failure logs a warning and skips the reply-quote decoration, while the message body itself relays normally.

## 2. Empty-string `avatar_url` rejected by Fluxer

When the source server of a followed channel has no icon configured, `message.author.avatarURL()` returns `null` for the resulting cross-post webhook message. The transformer's `|| ''` coercion sent an empty string in the `avatar_url`/`avatarURL` field on the webhook send call. Fluxer's API rejects this with `Invalid form body`, aborting the relay even after fix `#1` lets the transformer return.

`avatar_url` (Fluxer) and `avatarURL` (Discord) are now coerced to `undefined` when empty, so the field is omitted from the payload rather than sent as an invalid URL.

## Testing

Verified on my self-hosted instance:

- Followed external announcement channels and confirmed published messages — including text, mentions, attachments, and auto-embeds now relay cleanly to the linked Fluxer channel.
- Confirmed the warning line appears once per cross-posted message and the message body still relays.
- Confirmed that source servers without a custom icon now relay successfully (previously failed with `Invalid form body`).

Both fixes are required: without `#1` the relay never reaches the network call; without `#2` the network call gets an `Invalid form body` rejection whenever the source server has no icon.

Happy to adjust the commit or split if preferred.