### PR TITLE
Feature/self hosted domain support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@ BF_DISCORD_APP_ID=""
 
 BF_COMMAND_PREFIX="!b "
 
+# Self-hosted instance configuration (optional — defaults work for the official fluxer.app instance)
+# Set BF_FLUXER_DOMAIN to your instance's domain if you're running a self-hosted Fluxer server.
+# The API base and web base are derived automatically from this domain using the standard
+# operator stack conventions (docs.fluxer.app/operator), but can be overridden if needed.
+# These can also be set via CLI flags: --fluxer-domain, --fluxer-api-base, --fluxer-web-base
+BF_FLUXER_DOMAIN="fluxer.app"
+# BF_FLUXER_API_BASE="https://api.fluxer.app"     # default for fluxer.app; self-hosted: https://<domain>/api
+# BF_FLUXER_WEB_BASE="https://web.fluxer.app"     # default for fluxer.app; self-hosted: https://<domain>
+
 # Owner UserID for both Fluxer and Discord, used for Debugging commands like %list all
 BF_FLUXER_OWNER_ID=""
 BF_DISCORD_OWNER_ID=""

--- a/docker-compose-aio.yml
+++ b/docker-compose-aio.yml
@@ -15,6 +15,9 @@ services:
             DB_NAME: bifrost
             DB_USER: bifrost_user
             DB_PASS: ${POSTGRES_PASSWORD}
+            BF_FLUXER_DOMAIN: ${BF_FLUXER_DOMAIN:-fluxer.app}
+            BF_FLUXER_API_BASE: ${BF_FLUXER_API_BASE:-}
+            BF_FLUXER_WEB_BASE: ${BF_FLUXER_WEB_BASE:-}
         volumes:
             - ./config:/config
         networks:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,12 +6,12 @@ services:
       args:
         GIT_COMMIT: abc1234
         APP_VERSION: 1.2.3
-    container_name: bifrost
+    container_name: bifrost-test
     restart: unless-stopped
     env_file:
       - .env
     environment:
-      BF_FLUXER_DOMAIN: ${BF_FLUXER_DOMAIN:-fluxer.app}
+      BF_FLUXER_DOMAIN: chat.relicfree.company # Change this to your domain www.example.com
       BF_FLUXER_API_BASE: ${BF_FLUXER_API_BASE:-}
       BF_FLUXER_WEB_BASE: ${BF_FLUXER_WEB_BASE:-}
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,5 +10,9 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    environment:
+      BF_FLUXER_DOMAIN: ${BF_FLUXER_DOMAIN:-fluxer.app}
+      BF_FLUXER_API_BASE: ${BF_FLUXER_API_BASE:-}
+      BF_FLUXER_WEB_BASE: ${BF_FLUXER_WEB_BASE:-}
     volumes:
       - ./config:/config

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,7 +11,7 @@ services:
     env_file:
       - .env
     environment:
-      BF_FLUXER_DOMAIN: chat.relicfree.company # Change this to your domain www.example.com
+      BF_FLUXER_DOMAIN: ${BF_FLUXER_DOMAIN:-fluxer.app}   # # # Change this to your domain www.example.com
       BF_FLUXER_API_BASE: ${BF_FLUXER_API_BASE:-}
       BF_FLUXER_WEB_BASE: ${BF_FLUXER_WEB_BASE:-}
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
       args:
         GIT_COMMIT: abc1234
         APP_VERSION: 1.2.3
-    container_name: bifrost-test
+    container_name: bifrost
     restart: unless-stopped
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,9 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    environment:
+      BF_FLUXER_DOMAIN: ${BF_FLUXER_DOMAIN:-fluxer.app}
+      BF_FLUXER_API_BASE: ${BF_FLUXER_API_BASE:-}
+      BF_FLUXER_WEB_BASE: ${BF_FLUXER_WEB_BASE:-}
     volumes:
       - ./config:/config

--- a/src/commands/discord/handlers/ListDiscordCommandHandler.ts
+++ b/src/commands/discord/handlers/ListDiscordCommandHandler.ts
@@ -6,7 +6,7 @@ import DiscordCommandHandler, {
 import FluxerEntityResolver from '../../../services/entityResolver/FluxerEntityResolver';
 import logger from '../../../utils/logging/logger';
 import { chunkDescriptionLines, EmbedColors } from '../../../utils/embeds';
-import { DISCORD_OWNER_ID } from '../../../utils/env';
+import { DISCORD_OWNER_ID, FLUXER_DOMAIN } from '../../../utils/env';
 
 export default class ListDiscordCommandHandler extends DiscordCommandHandler {
     constructor(
@@ -34,7 +34,7 @@ export default class ListDiscordCommandHandler extends DiscordCommandHandler {
                 const fluxerName =
                     (fluxerChannel as { name?: string } | null)?.name ??
                     link.fluxerChannelId;
-                const fluxerUrl = `https://fluxer.app/channels/${fluxerGuildId}/${link.fluxerChannelId}`;
+                const fluxerUrl = `https://${FLUXER_DOMAIN}/channels/${fluxerGuildId}/${link.fluxerChannelId}`;
                 const suffix = showLinkId ? ` | \`${link.linkId}\`` : '';
                 // Discord on left, Fluxer on right (viewing from Discord)
                 return `<#${link.discordChannelId}> ←→ [#${fluxerName}](${fluxerUrl})${suffix}\n  └ \`${link.discordChannelId}\` · \`${link.fluxerChannelId}\``;

--- a/src/commands/discord/handlers/StatsDiscordCommandHandler.ts
+++ b/src/commands/discord/handlers/StatsDiscordCommandHandler.ts
@@ -9,6 +9,7 @@ import { EmbedColors } from '../../../utils/embeds';
 import {
     DISCORD_APP_ID,
     FLUXER_APP_ID,
+    FLUXER_WEB_BASE,
     GIT_COMMIT,
     REPO_URL,
 } from '../../../utils/env';
@@ -50,7 +51,7 @@ export default class StatsDiscordCommandHandler extends DiscordCommandHandler {
         const dbStats = await this.dbStatsService.getStats();
 
         const perms = '536947712';
-        const inviteValue = `[Fluxer](${generateFluxerBotInviteLink(FLUXER_APP_ID, perms)}) | [Discord](${generateDiscordBotInviteLink(DISCORD_APP_ID, perms)})`;
+        const inviteValue = `[Fluxer](${generateFluxerBotInviteLink(FLUXER_APP_ID, perms, FLUXER_WEB_BASE)}) | [Discord](${generateDiscordBotInviteLink(DISCORD_APP_ID, perms)})`;
 
         const buildValue = GIT_COMMIT
             ? REPO_URL

--- a/src/commands/fluxer/handlers/StatsFluxerCommandHandler.ts
+++ b/src/commands/fluxer/handlers/StatsFluxerCommandHandler.ts
@@ -7,6 +7,7 @@ import { EmbedColors } from '../../../utils/embeds';
 import {
     DISCORD_APP_ID,
     FLUXER_APP_ID,
+    FLUXER_WEB_BASE,
     GIT_COMMIT,
     REPO_URL,
 } from '../../../utils/env';
@@ -45,7 +46,7 @@ export default class StatsFluxerCommandHandler extends FluxerCommandHandler {
         const usedHeap = getHeapUsageMB();
 
         const perms = '536947712';
-        const inviteValue = `[Fluxer](${generateFluxerBotInviteLink(FLUXER_APP_ID, perms)}) | [Discord](${generateDiscordBotInviteLink(DISCORD_APP_ID, perms)})`;
+        const inviteValue = `[Fluxer](${generateFluxerBotInviteLink(FLUXER_APP_ID, perms, FLUXER_WEB_BASE)}) | [Discord](${generateDiscordBotInviteLink(DISCORD_APP_ID, perms)})`;
 
         const buildValue = GIT_COMMIT
             ? REPO_URL

--- a/src/fluxer.ts
+++ b/src/fluxer.ts
@@ -13,7 +13,7 @@ import {
 import { EmbedColors } from './utils/embeds';
 import logger from './utils/logging/logger';
 import FluxerCommandHandler from './commands/fluxer/FluxerCommandHandler';
-import { COMMAND_PREFIX, DELETE_INVOCATION, FLUXER_TOKEN } from './utils/env';
+import { COMMAND_PREFIX, DELETE_INVOCATION, FLUXER_API_BASE, FLUXER_TOKEN } from './utils/env';
 import { LinkService } from './services/LinkService';
 import LinkFluxerCommandHandler from './commands/fluxer/handlers/LinkFluxerCommandHandler';
 import UnlinkFluxerCommandHandler from './commands/fluxer/handlers/UnlinkFluxerCommandHandler';
@@ -59,6 +59,9 @@ const startFluxerClient = async ({
     const client = new Client({
         intents: 0,
         waitForGuilds: true,
+        rest: {
+            api: FLUXER_API_BASE,
+        },
         presence: {
             status: 'online',
             custom_status: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
     DISCORD_HEALTH_URL,
     FLUXER_APP_ID,
     FLUXER_HEALTH_URL,
+    FLUXER_WEB_BASE,
     GIT_COMMIT,
     METRICS_PORT,
     QUEUE_TTL_MS,
@@ -179,7 +180,8 @@ const main = async () => {
     logger.info(`Discord Bot Invite Link: ${discordBotInviteLink}`);
     const fluxerBotInviteLink = generateFluxerBotInviteLink(
         FLUXER_APP_ID,
-        perms
+        perms,
+        FLUXER_WEB_BASE
     );
     logger.info(`Fluxer Bot Invite Link: ${fluxerBotInviteLink}`);
 

--- a/src/services/MessageQueueService.ts
+++ b/src/services/MessageQueueService.ts
@@ -14,7 +14,7 @@ export type SerializableEmbed = ReturnType<WebhookEmbed['toPlainObject']>;
 export type SerializableWebhookMessageData = {
     content: string;
     username: string;
-    avatarURL: string;
+    avatarURL?: string;
     attachments?: WebhookAttachment[];
     embeds?: SerializableEmbed[];
 };

--- a/src/services/WebhookService.ts
+++ b/src/services/WebhookService.ts
@@ -25,7 +25,7 @@ export type WebhookAttachment = {
 export type WebhookMessageData = {
     content: string;
     username: string;
-    avatarURL: string;
+    avatarURL?: string;
     attachments?: WebhookAttachment[];
     embeds?: WebhookEmbed[];
 };
@@ -229,7 +229,7 @@ export class WebhookService {
                 {
                     content: data.content,
                     username: data.username,
-                    avatar_url: data.avatarURL,
+                    avatar_url: data.avatarURL || undefined,
                     files:
                         data.attachments?.map((attachment) => ({
                             url: attachment.url,

--- a/src/services/messageTransformer/DiscordMessageTransformer.ts
+++ b/src/services/messageTransformer/DiscordMessageTransformer.ts
@@ -128,7 +128,7 @@ export default class DiscordMessageTransformer extends MessageTransformer<
         return {
             content: messageContent,
             username: message.author.username,
-            avatarURL: message.author.avatarURL() || '',
+            avatarURL: message.author.avatarURL() ?? undefined,
             attachments: attachments,
             embeds,
         };

--- a/src/services/messageTransformer/FluxerMessageTransformer.ts
+++ b/src/services/messageTransformer/FluxerMessageTransformer.ts
@@ -5,6 +5,19 @@ import { breakMentions, sanitizeMentions } from '../../utils/sanitizeMentions';
 import { buildFluxerStickerUrl } from '../../utils/buildStickerUrl';
 import WebhookEmbed from '../WebhookEmbed';
 import { GeneralEmoji } from '../../utils/emojis';
+import { FLUXER_DOMAIN } from '../../utils/env';
+
+function buildFluxerAvatarURL(
+    userId: string,
+    avatarHash: string | null
+): string | undefined {
+    if (!avatarHash) return undefined;
+    if (FLUXER_DOMAIN === 'fluxer.app') {
+        const ext = avatarHash.startsWith('a_') ? 'gif' : 'png';
+        return `https://fluxerusercontent.com/avatars/${userId}/${avatarHash}.${ext}`;
+    }
+    return `https://${FLUXER_DOMAIN}/media/avatars/${userId}/${avatarHash}.webp?size=160`;
+}
 
 export default class FluxerMessageTransformer extends MessageTransformer<
     Message,
@@ -94,7 +107,7 @@ export default class FluxerMessageTransformer extends MessageTransformer<
         return {
             content: emojiReplacedContent,
             username: message.author.username,
-            avatarURL: message.author.avatarURL() || '',
+            avatarURL: buildFluxerAvatarURL(message.author.id, message.author.avatar),
             attachments: attachments,
             embeds,
         };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -55,6 +55,43 @@ export const DISCORD_TOKEN = process.env.BF_DISCORD_TOKEN || '';
 export const FLUXER_APP_ID = process.env.BF_FLUXER_APP_ID || '';
 export const DISCORD_APP_ID = process.env.BF_DISCORD_APP_ID || '';
 
+function getCliArg(flag: string): string | null {
+    // Supports both `--flag=value` and `--flag value` forms
+    const eqArg = process.argv.find((arg) => arg.startsWith(`${flag}=`));
+    if (eqArg) return eqArg.slice(flag.length + 1);
+    const idx = process.argv.indexOf(flag);
+    if (idx !== -1 && process.argv[idx + 1]) return process.argv[idx + 1];
+    return null;
+}
+
+// Domain of the Fluxer instance to connect to.
+// Resolution order: --fluxer-domain CLI flag > BF_FLUXER_DOMAIN env var > default.
+// Self-hosted operators should set this to their instance domain (e.g. chat.example.com).
+export const FLUXER_DOMAIN =
+    getCliArg('--fluxer-domain') || process.env.BF_FLUXER_DOMAIN || 'fluxer.app';
+
+// Base URL for the Fluxer REST API and gateway discovery.
+// The hosted fluxer.app instance serves the API at api.fluxer.app, but the self-hosted
+// Docker Compose stack (see docs.fluxer.app/operator) serves it at <domain>/api.
+// Resolution order: --fluxer-api-base CLI flag > BF_FLUXER_API_BASE env var > derived default.
+export const FLUXER_API_BASE =
+    getCliArg('--fluxer-api-base') ||
+    process.env.BF_FLUXER_API_BASE ||
+    (FLUXER_DOMAIN === 'fluxer.app'
+        ? `https://api.${FLUXER_DOMAIN}`
+        : `https://${FLUXER_DOMAIN}/api`);
+
+// Base URL for the Fluxer web client, used in invite links and channel URLs.
+// The hosted fluxer.app instance uses the web.fluxer.app subdomain, but self-hosted
+// instances serve the web client at the root domain.
+// Resolution order: --fluxer-web-base CLI flag > BF_FLUXER_WEB_BASE env var > derived default.
+export const FLUXER_WEB_BASE =
+    getCliArg('--fluxer-web-base') ||
+    process.env.BF_FLUXER_WEB_BASE ||
+    (FLUXER_DOMAIN === 'fluxer.app'
+        ? `https://web.${FLUXER_DOMAIN}`
+        : `https://${FLUXER_DOMAIN}`);
+
 export const DISCORD_HEALTH_URL = process.env.BF_DISCORD_HEALTH_URL || null;
 export const FLUXER_HEALTH_URL = process.env.BF_FLUXER_HEALTH_URL || null;
 

--- a/src/utils/generateBotInvite.ts
+++ b/src/utils/generateBotInvite.ts
@@ -7,7 +7,8 @@ export const generateDiscordBotInviteLink = (
 
 export const generateFluxerBotInviteLink = (
     clientId: string,
-    permissions: string
+    permissions: string,
+    fluxerWebBase: string
 ) => {
-    return `https://web.fluxer.app/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=${permissions}`;
+    return `${fluxerWebBase}/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=${permissions}`;
 };


### PR DESCRIPTION
Adding support to run Bifrost with a custom domain by adding a CLI flag `--fluxer-domain`, as well as a env var `BF_FLUXER_DOMAIN`. This should replace the hardcoded path from Fluxer's default if set to a custom path. You might want to handle the substitution differently where it comes to the env var for the compose file, since right now it's a default value.

The invite link also removes the "web." path from the invite when the custom domain flag is used. 